### PR TITLE
Increase ChatKit widget width

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,7 +66,7 @@ export default function App() {
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-slate-100 p-4">
-      <ChatKit control={control} className="h-[600px] w-full max-w-[320px]" />
+      <ChatKit control={control} className="h-[600px] min-w-[800px]" />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- set the ChatKit component to maintain a minimum width of 800px for improved readability

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e6817cfb6c83239d30cc1be76cd06e