### PR TITLE
Add header and adjust layout for ChatKit page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,8 +65,13 @@ export default function App() {
   });
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-100 p-4">
-      <ChatKit control={control} className="h-[600px] max-w-[800px]" />
+    <main className="flex min-h-screen flex-col bg-white text-black">
+      <header className="border-b border-slate-200 px-6 py-4 text-xl font-semibold">
+        Ask mikulskibartosz.name
+      </header>
+      <div className="flex flex-1 justify-center p-6">
+        <ChatKit control={control} className="h-full max-w-[800px] flex-1" />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- set the main layout to use a white background and black text
- add a header that displays "Ask mikulskibartosz.name"
- stretch the ChatKit widget to fill the full page height beneath the header

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6b517f5a88323ad06673b3c7ad595